### PR TITLE
Fix converting grays to ANSI 256 color palette

### DIFF
--- a/colorful/ansi.py
+++ b/colorful/ansi.py
@@ -58,7 +58,7 @@ def round(value):
     return int(math.ceil(value))
 
 
-def rgb_to_ansi265(r, g, b):
+def rgb_to_ansi256(r, g, b):
     """
     Convert RGB to ANSI 256 color
     """

--- a/colorful/ansi.py
+++ b/colorful/ansi.py
@@ -68,7 +68,7 @@ def rgb_to_ansi256(r, g, b):
         if r > 248:
             return 231
 
-        return round(((r - 8) / 247) * 24) + 232
+        return round(((r - 8) / 247.0) * 24) + 232
 
     ansi_r = 36 * round(r / 255.0 * 5.0)
     ansi_g = 6 * round(g / 255.0 * 5.0)

--- a/colorful/core.py
+++ b/colorful/core.py
@@ -72,7 +72,7 @@ def translate_rgb_to_ansi_code(red, green, blue, offset, colormode):
         return start_code, end_code
 
     if colormode == terminal.ANSI_256_COLORS:
-        color_code = ansi.rgb_to_ansi265(red, green, blue)
+        color_code = ansi.rgb_to_ansi256(red, green, blue)
         start_code = ansi.ANSI_ESCAPE_CODE.format(code='{base};5;{code}'.format(
             base=8 + offset, code=color_code))
         end_code = ansi.ANSI_ESCAPE_CODE.format(code=offset + ansi.COLOR_CLOSE_OFFSET)

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+"""
+    colorful
+    ~~~~~~~~
+
+    Terminal string styling done right, in Python.
+
+    :copyright: (c) 2017 by Timo Furrer <tuxtimo@gmail.com>
+    :license: MIT, see LICENSE for more details.
+"""
+
+import os
+
+import pytest
+
+# do not overwrite module
+os.environ['COLORFUL_NO_MODULE_OVERWRITE'] = '1'
+
+import colorful.ansi as ansi  # noqa
+
+
+@pytest.mark.parametrize('r, g, b, result', [
+    (118, 118, 118, 243),
+])
+def test_rgb_to_ansi256(r, g, b, result):
+    """
+    Test converting an RGB value to an ANSI 256 color.
+    """
+
+    assert result == ansi.rgb_to_ansi256(r, g, b)


### PR DESCRIPTION
On Python 2, grays were converted to ANSI color 232 (black) due to integer division being used.