### PR TITLE
Catch AttributeError in case sys.stdout was monkey patched

### DIFF
--- a/colorful/core.py
+++ b/colorful/core.py
@@ -20,7 +20,7 @@ from . import ansi
 from . import rgb
 from . import styles
 from . import terminal
-from .utils import PY2, DEFAULT_ENCODE, UNICODE
+from .utils import PY2, DEFAULT_ENCODING, UNICODE
 
 #: Holds the name of the env variable which is
 #  used as path to the default rgb.txt file
@@ -209,7 +209,7 @@ def style_string(string, ansi_style, colormode, nested=False):
     # replace nest placeholders with the current begin style
     if PY2:
         if isinstance(string, str):
-            string = string.decode('utf-8' if DEFAULT_ENCODE is None else DEFAULT_ENCODE)
+            string = string.decode(DEFAULT_ENCODING)
     string = UNICODE(string).replace(ansi.NEST_PLACEHOLDER, ansi_start_code)
 
     return '{start_code}{string}{end_code}{nest_ph}'.format(
@@ -232,7 +232,7 @@ class ColorfulString(object):
             return self.styled_string
 
         def __str__(self):
-            return self.styled_string.encode('utf-8' if DEFAULT_ENCODE is None else DEFAULT_ENCODE)
+            return self.styled_string.encode(DEFAULT_ENCODING)
     else:
         def __str__(self):
             return self.styled_string

--- a/colorful/utils.py
+++ b/colorful/utils.py
@@ -19,7 +19,12 @@ if PY2:
 else:
     UNICODE = str
 
-DEFAULT_ENCODE = sys.stdout.encoding
+# Catch error in case sys.stdout was patched with an object that doesn't provide
+# the 'encoding' attribute.
+try:
+    DEFAULT_ENCODING = sys.stdout.encoding or 'utf-8'
+except AttributeError:
+    DEFAULT_ENCODING = 'utf-8'
 
 
 def hex_to_rgb(value):


### PR DESCRIPTION
 .. and the custom object doesn't provide the 'encoding' attribute.

 Also renamed DEFAULT_ENCODE -> DEFAULT_ENCODING and avoided the
 repeated usage of if expressions by directly setting the
 DEFAULT_ENCODING to 'utf-8' in case it is None or Empty.

Fixes #14 