### PR TITLE
include license file in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include colorful/data/*.txt
 include colorful/data/*.json
 include README.md
+include LICENSE


### PR DESCRIPTION
The MIT license requires that it be distributed with the software.

> The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

This change will include the license file in future sdists.