### PR TITLE
Add skipif for tests that fail without a tty

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,6 +14,7 @@
 from __future__ import print_function
 
 import os
+import sys
 
 import pytest
 
@@ -430,6 +431,7 @@ def test_invalid_color_name():
     assert str(exc.value) == expected
 
 
+@pytest.mark.skipif(not sys.stdout.isatty(), reason='fails without a tty')
 @pytest.mark.parametrize('env,expected', [
     ({'COLORFUL_DISABLE': '1'}, terminal.NO_COLORS),
     ({'COLORTERM': 'truecolor'}, terminal.TRUE_COLORS),
@@ -451,6 +453,7 @@ def test_colorful_obj_color_auto_detection(env, expected):
     os.environ = os_env_backup
 
 
+@pytest.mark.skipif(not sys.stdout.isatty(), reason='fails without a tty')
 def test_reading_color_palette(tmpdir):
     """
     Test reading color palette from file

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -11,6 +11,7 @@
 """
 
 import os
+import sys
 
 import pytest
 
@@ -20,6 +21,7 @@ os.environ['COLORFUL_NO_MODULE_OVERWRITE'] = '1'
 import colorful.terminal as terminal  # noqa
 
 
+@pytest.mark.skipif(not sys.stdout.isatty(), reason='fails without a tty')
 @pytest.mark.parametrize('env,expected', [
     # test force color settings
     ({'COLORFUL_DISABLE': '1'}, terminal.NO_COLORS),


### PR DESCRIPTION
I'm working on packaging this for Fedora, and while running the tests I realized that several tests fail in a [mock](https://github.com/rpm-software-management/mock), which is a tool to build RPMs in a chroot (not to be confused with [`unittest.mock`](https://docs.python.org/3/library/unittest.mock.html)).  The tests do pass if running rpmbuild directly.  After some troubleshooting I realized the difference is that mock doesn't have stdout attached to the terminal.  This pull request adds `skipif` conditions for those tests.