### PR TITLE
Make it work on Windows without colorama calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ We recommend to use the latest version released on [PyPI](https://pypi.python.or
 pip install colorful
 ```
 
-*Note: on a Windows system it will install ``colorama`` as a dependency to ensure proper ANSI support.*
-
 **colorful** does not require any special setup in order to be used:
 
 ```python

--- a/colorful/__init__.py
+++ b/colorful/__init__.py
@@ -25,8 +25,7 @@ __version__ = '0.5.0'
 
 # if we are on Windows we have to init colorama
 if platform.system() == 'Windows':
-    from colorama import init
-    init()
+    os.system('color')
 
 
 class ColorfulModule(types.ModuleType):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-# only require colorama if we are on windows
-
-colorama;platform_system=="Windows"


### PR DESCRIPTION
@timofurrer This doesn't actually update performance, but keeps it the same on windows without additional dependencies. I have tested and can confirm that it works on `CMD` and `PowerShell`, just as well as it used to, without colorama, but not as well as Ubuntu.

This works because of this new line, which seems to enable `ANSI` codes on Windows:

```py
os.system("color")
```