### PR TITLE
fix setup(colormode=NO_COLORS)

### DIFF
--- a/colorful/core.py
+++ b/colorful/core.py
@@ -403,7 +403,7 @@ class Colorful(object):
                                   color names to it's corresponding RGB value
         :param bool extend_colors: extend the active color palette instead of replacing it
         """
-        if colormode:
+        if colormode is not None:
             self.colormode = colormode
 
         if colorpalette:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -507,6 +507,18 @@ def test_colorful_obj_setup_with_extending_palette():
     assert str(colorful.black) == '\033[38;2;0;0;0m'
 
 
+def test_colorful_obj_setup_with_no_colors():
+    """
+    Test setup switching an existing colorful object to NO_COLORS (disabled)
+    """
+    colorful = core.Colorful(colormode=terminal.ANSI_8_COLORS)
+    colorful.setup(colormode=terminal.NO_COLORS)
+
+    assert colorful.colormode == terminal.NO_COLORS
+
+    assert str(colorful.red('color is illusion')) == 'color is illusion'
+
+
 @pytest.mark.parametrize('method_name, colorname, expected', [
     ('use_8_ansi_colors', 'black', '\033[30m'),
     ('use_16_ansi_colors', 'black', '\033[30m'),


### PR DESCRIPTION
This fixes `Colorful.setup(colormode=terminal.NO_COLORS)`, which was confusing the falsy value of NO_COLORS with the default argument value of None.

Consequently, `cf.with_setup(colormode=NO_COLORS)` should work now.