### PR TITLE
test_reading_color_palette: specify colormode

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -453,7 +453,6 @@ def test_colorful_obj_color_auto_detection(env, expected):
     os.environ = os_env_backup
 
 
-@pytest.mark.skipif(not sys.stdout.isatty(), reason='fails without a tty')
 def test_reading_color_palette(tmpdir):
     """
     Test reading color palette from file
@@ -464,7 +463,7 @@ def test_reading_color_palette(tmpdir):
 0 0 0 myBlack
 255 255 255      myWhite""")
 
-    colorful = core.Colorful(colorpalette=str(palette_file))
+    colorful = core.Colorful(colormode=terminal.ANSI_8_COLORS, colorpalette=str(palette_file))
     assert str(colorful.myBlack) == '\033[30m'
     assert str(colorful.myWhite) == '\033[37m'
 


### PR DESCRIPTION
This test was failing locally for me:

```
>       assert str(colorful.myBlack) == '\033[30m'
E       AssertionError: assert '\x1b[38;2;0;0;0m' == '\x1b[30m'
```

I assume because the colormode it detected here was different than the colormode when the assertion was written.

It had a skip condition on it to require a tty, but I'm guessing that was a copy-paste and terminal detection was not supposed to be part of the palette-reading test.