### PR TITLE
Read version from ast.Constant instead of ast.Str

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,11 @@ class VersionFinder(ast.NodeVisitor):
     def visit_Assign(self, node):
         try:
             if node.targets[0].id == '__version__':
-                self.version = node.value.s
+                try:
+                    # Python 3.8+
+                    self.version = node.value.value
+                except AttributeError:
+                    self.version = node.value.s
         except:
             pass
 


### PR DESCRIPTION
`ast.Str` has been deprecated in favor of `ast.Constant` since Python 3.8. `ast.Constant` retained the s attribute for compatibility until Python 3.14.  In order to be compatible with Python 3.14, `VersionFinder` should check for `ast.Constant.value` first, and then fall back to `ast.Str.s` for older Pythons.

https://docs.python.org/3.14/whatsnew/3.14.html#id6