### PR TITLE
fix: `DualOutput` object has no attribute `isatty`

### DIFF
--- a/colorful/terminal.py
+++ b/colorful/terminal.py
@@ -45,7 +45,7 @@ def detect_color_support(env):  # noqa
         return TRUE_COLORS
 
     # if we are not a tty
-    if not sys.stdout.isatty():
+    if hasattr(sys.stdout, 'isatty') and not sys.stdout.isatty():
         return NO_COLORS
 
     colorterm_env = env.get('COLORTERM')


### PR DESCRIPTION
I encontered this error when I submit a slurm job in HPC, although `sys.stdout` doesn't have `isatty` here, it won't fail even if we don't set `NO_COLORS`, so I think it should be safe to skip the isatty check here under such condition.

```log
File "colorful/init.py", line 133, in <module>
sys.modules[name] = ColorfulModule(Colorful(), name)
^^^^^^^^^^
File "colorful/core.py", line 342, in init
colormode = terminal.detect_color_support(env=os.environ)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "colorful/terminal.py", line 48, in detect_color_support
if not sys.stdout.isatty():
^^^^^^^^^^^^^^^^^
AttributeError: 'DualOutput' object has no attribute 'isatty'
```